### PR TITLE
Add operating, stopping, and service safety records

### DIFF
--- a/safety/operating-states.json
+++ b/safety/operating-states.json
@@ -1,0 +1,97 @@
+{
+  "schema_version": "1.0.0",
+  "model_version": "0.1.0",
+  "states": [
+    {"id": "OFF", "invariant": "No commanded motion; stored energy may remain.", "access": "No access permission is implied."},
+    {"id": "QUARANTINE", "invariant": "Input is enclosed and destructive processing is inhibited.", "access": "Presentation interface only under its access contract."},
+    {"id": "READY", "invariant": "One named process and configuration has passed every admission guard.", "access": "Hazardous and routing boundaries remain closed."},
+    {"id": "RUN", "invariant": "The admitted process remains inside its verified apparatus envelope.", "access": "No access to hazardous motion, pressure, atmosphere, or routing."},
+    {"id": "CONTROLLED_REFUSAL", "invariant": "New feed is inhibited and an event-specific safe-stop sequence is active.", "access": "All affected access remains locked."},
+    {"id": "COOLDOWN_CLEARING", "invariant": "Residual motion, pressure, temperature, atmosphere, or material prevents access.", "access": "Only non-exposing observations are allowed."},
+    {"id": "USER_ACCESS", "invariant": "Every user-access residual-hazard criterion is directly verified.", "access": "Only designated low-energy compartments are unlocked."},
+    {"id": "SERVICE_LOCKOUT", "invariant": "Hazardous energy is isolated and independently verified.", "access": "Only the authorized service scope is exposed."},
+    {"id": "FAULT_LATCHED", "invariant": "Restart is prohibited pending the recorded recovery path.", "access": "Access follows the event-specific stop and service boundary."}
+  ],
+  "transitions": [
+    {
+      "id": "TX-001", "from": "OFF", "to": "QUARANTINE", "trigger": "Local start request",
+      "guards": ["Controller self-test passes", "No latched fault", "Quarantine enclosure is available"],
+      "actions": ["Initialize physical and epistemic ledgers", "Keep destructive actuators inhibited"],
+      "completion_evidence": ["Configuration identity recorded", "Protective channels report available"],
+      "timeout_fallback": "FAULT_LATCHED", "reset_authority": "user",
+      "ledger": ["startup observations", "configuration identity", "self-test results"]
+    },
+    {
+      "id": "TX-002", "from": "QUARANTINE", "to": "READY", "trigger": "Named process requested",
+      "guards": ["Input knowledge contract passes", "Process compatibility passes", "Applicable manifest is complete", "Required sensors and interlocks are verified", "No open run blocker"],
+      "actions": ["Bind batch, process, apparatus, and manifest versions", "Arm only the named route"],
+      "completion_evidence": ["Admission decision recorded", "All guard results current"],
+      "timeout_fallback": "QUARANTINE", "reset_authority": "user",
+      "ledger": ["admission evidence", "unresolved uncertainty", "authorized process"]
+    },
+    {
+      "id": "TX-003", "from": "READY", "to": "RUN", "trigger": "Local run command",
+      "guards": ["Every closure and collector is proved seated", "Safety data remain fresh", "Start sequence is valid"],
+      "actions": ["Start extraction or cooling prerequisites", "Start drive under bounded acceleration", "Enable feed only after stable state"],
+      "completion_evidence": ["Speed, airflow, pressure, vibration, and temperature lie within startup envelope"],
+      "timeout_fallback": "CONTROLLED_REFUSAL", "reset_authority": "user",
+      "ledger": ["commanded and observed startup sequence", "initial process measurements"]
+    },
+    {
+      "id": "TX-004", "from": "RUN", "to": "CONTROLLED_REFUSAL", "trigger": "Protective limit, containment fault, sensor invalidity, or emergency stop",
+      "guards": ["None; refusal has priority over production"],
+      "actions": ["Inhibit feed", "Select the registered event response", "Preserve raw observations"],
+      "completion_evidence": ["Feed isolation observed", "Stop-matrix actions acknowledged"],
+      "timeout_fallback": "FAULT_LATCHED", "reset_authority": "trained_service",
+      "ledger": ["trip source", "raw pre-trip history", "commands and feedback"]
+    },
+    {
+      "id": "TX-005", "from": "RUN", "to": "COOLDOWN_CLEARING", "trigger": "Normal stop or batch completion",
+      "guards": ["No protective event is active"],
+      "actions": ["Inhibit feed", "Execute normal stop", "Clear admitted material through designated routes"],
+      "completion_evidence": ["Drive no longer commanded", "Batch destinations and residue recorded"],
+      "timeout_fallback": "FAULT_LATCHED", "reset_authority": "user",
+      "ledger": ["normal stop measurements", "batch closure status"]
+    },
+    {
+      "id": "TX-006", "from": "CONTROLLED_REFUSAL", "to": "COOLDOWN_CLEARING", "trigger": "Active stop actions complete",
+      "guards": ["No escalation requires evacuation or continued fault response"],
+      "actions": ["Maintain required extraction or cooling", "Continue residual-hazard observation"],
+      "completion_evidence": ["Event response has reached its defined clearing phase"],
+      "timeout_fallback": "FAULT_LATCHED", "reset_authority": "trained_service",
+      "ledger": ["stop timing", "residual-hazard trajectory"]
+    },
+    {
+      "id": "TX-007", "from": "COOLDOWN_CLEARING", "to": "USER_ACCESS", "trigger": "User-access request",
+      "guards": ["Zero hazardous motion independently verified", "Pressure and atmosphere safe", "Accessible temperatures safe", "No event requires trained service"],
+      "actions": ["Unlock only the named user-service compartment"],
+      "completion_evidence": ["All access criteria current at unlock", "Unlocked compartment identity recorded"],
+      "timeout_fallback": "FAULT_LATCHED", "reset_authority": "user",
+      "ledger": ["access evidence", "lock state"]
+    },
+    {
+      "id": "TX-008", "from": "FAULT_LATCHED", "to": "SERVICE_LOCKOUT", "trigger": "Authorized service entry",
+      "guards": ["Event-specific service scope identified", "Hazardous-energy isolation procedure selected"],
+      "actions": ["Isolate energy", "Verify residual energy independently", "Record service authority"],
+      "completion_evidence": ["Every isolation point and verification result recorded"],
+      "timeout_fallback": "FAULT_LATCHED", "reset_authority": "trained_service",
+      "ledger": ["isolation points", "verification measurements", "service authority"]
+    },
+    {
+      "id": "TX-009", "from": "SERVICE_LOCKOUT", "to": "QUARANTINE", "trigger": "Return-to-service request",
+      "guards": ["Service record complete", "Configuration identity updated", "Guards and interlocks pass", "Required recommissioning tests pass"],
+      "actions": ["Close protected access", "Run self-test without destructive processing", "Clear only resolved fault latch"],
+      "completion_evidence": ["Return-to-service evidence linked", "No unresolved blocker permits RUN"],
+      "timeout_fallback": "FAULT_LATCHED", "reset_authority": "trained_service",
+      "ledger": ["work performed", "parts and configuration", "test results"]
+    },
+    {
+      "id": "TX-010", "from": "*", "to": "FAULT_LATCHED", "trigger": "Power restoration, controller restart, impossible state, or unhandled transition",
+      "guards": ["None; no automatic return to prior hazardous state"],
+      "actions": ["Keep feed and hazardous actuation inhibited", "Reconstruct observed state without asserting prior safety"],
+      "completion_evidence": ["Restart cause and available evidence recorded"],
+      "timeout_fallback": "FAULT_LATCHED", "reset_authority": "trained_service",
+      "ledger": ["restart event", "last durable state", "current sensor availability"]
+    }
+  ]
+}

--- a/safety/schemas/operating-states.schema.json
+++ b/safety/schemas/operating-states.schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://standardgalactic.github.io/Centerfuge/safety/schemas/operating-states.schema.json",
+  "title": "Centerfuge operating-state model",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "model_version", "states", "transitions"],
+  "properties": {
+    "schema_version": {"const": "1.0.0"},
+    "model_version": {"type": "string", "minLength": 1},
+    "states": {
+      "type": "array",
+      "minItems": 9,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "invariant", "access"],
+        "properties": {
+          "id": {"type": "string", "minLength": 1},
+          "invariant": {"type": "string", "minLength": 1},
+          "access": {"type": "string", "minLength": 1}
+        }
+      }
+    },
+    "transitions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "from", "to", "trigger", "guards", "actions", "completion_evidence", "timeout_fallback", "reset_authority", "ledger"],
+        "properties": {
+          "id": {"type": "string", "pattern": "^TX-[0-9]{3}$"},
+          "from": {"type": "string", "minLength": 1},
+          "to": {"type": "string", "minLength": 1},
+          "trigger": {"type": "string", "minLength": 1},
+          "guards": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+          "actions": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+          "completion_evidence": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+          "timeout_fallback": {"type": "string", "minLength": 1},
+          "reset_authority": {"enum": ["automatic", "user", "trained_service", "protected_service"]},
+          "ledger": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}}
+        }
+      }
+    }
+  }
+}

--- a/safety/schemas/service-maintenance.schema.json
+++ b/safety/schemas/service-maintenance.schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://standardgalactic.github.io/Centerfuge/safety/schemas/service-maintenance.schema.json",
+  "title": "Centerfuge service and maintenance register",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "register_version", "components"],
+  "properties": {
+    "schema_version": {"const": "1.0.0"},
+    "register_version": {"type": "string", "minLength": 1},
+    "components": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "component", "service_class", "access_state", "tasks", "interval_basis", "event_triggers", "return_to_service", "consumables", "status", "open_questions"],
+        "properties": {
+          "id": {"type": "string", "pattern": "^SVC-[0-9]{3}$"},
+          "component": {"type": "string", "minLength": 1},
+          "service_class": {"enum": ["USER", "TRAINED", "PROTECTED_REPLACE_ONLY"]},
+          "access_state": {"enum": ["USER_ACCESS", "SERVICE_LOCKOUT"]},
+          "tasks": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+          "interval_basis": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+          "event_triggers": {"type": "array", "items": {"type": "string", "minLength": 1}},
+          "return_to_service": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+          "consumables": {"type": "array", "items": {"type": "string", "minLength": 1}},
+          "status": {"enum": ["modeled", "apparatus_specific_open", "verified"]},
+          "open_questions": {"type": "array", "items": {"type": "string", "minLength": 1}}
+        }
+      }
+    }
+  }
+}

--- a/safety/schemas/stop-recovery.schema.json
+++ b/safety/schemas/stop-recovery.schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://standardgalactic.github.io/Centerfuge/safety/schemas/stop-recovery.schema.json",
+  "title": "Centerfuge stop and recovery matrix",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "matrix_version", "events"],
+  "properties": {
+    "schema_version": {"const": "1.0.0"},
+    "matrix_version": {"type": "string", "minLength": 1},
+    "events": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "hazards", "trigger", "stop_class", "actions", "access_release", "reset_authority", "verification", "status", "open_questions"],
+        "properties": {
+          "id": {"type": "string", "pattern": "^EV-[0-9]{3}$"},
+          "hazards": {"type": "array", "minItems": 1, "items": {"type": "string", "pattern": "^HZ-[0-9]{3}$"}},
+          "trigger": {"type": "string", "minLength": 1},
+          "stop_class": {"enum": ["normal", "protective", "emergency"]},
+          "actions": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["feed", "drive", "brake", "extraction", "cooling", "gates", "alarm", "latch"],
+            "properties": {
+              "feed": {"enum": ["inhibit", "unchanged"]},
+              "drive": {"enum": ["remove_torque", "controlled_deceleration", "unchanged"]},
+              "brake": {"enum": ["apply", "coast", "apparatus_specific"]},
+              "extraction": {"enum": ["maintain", "stop", "isolate", "apparatus_specific"]},
+              "cooling": {"enum": ["maintain", "stop", "apparatus_specific", "not_applicable"]},
+              "gates": {"enum": ["hold", "isolate", "apparatus_specific"]},
+              "alarm": {"enum": ["local", "local_and_remote"]},
+              "latch": {"type": "boolean"}
+            }
+          },
+          "access_release": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+          "reset_authority": {"enum": ["user", "trained_service", "protected_service"]},
+          "verification": {"type": "string", "minLength": 1},
+          "status": {"enum": ["modeled", "apparatus_specific_open", "verified"]},
+          "open_questions": {"type": "array", "items": {"type": "string", "minLength": 1}}
+        }
+      }
+    }
+  }
+}

--- a/safety/service-maintenance.json
+++ b/safety/service-maintenance.json
@@ -1,0 +1,96 @@
+{
+  "schema_version": "1.0.0",
+  "register_version": "0.1.0",
+  "components": [
+    {
+      "id": "SVC-001", "component": "Sealed product and residue bins", "service_class": "USER", "access_state": "USER_ACCESS",
+      "tasks": ["Inspect seating and damage", "Exchange or empty without opening the process boundary", "Clean external contact surfaces"],
+      "interval_basis": ["Before every run", "Capacity indication", "Every removal"],
+      "event_triggers": ["Collector detachment", "Leak", "Impact", "Incorrect destination"],
+      "return_to_service": ["Correct bin identity verified", "Seal and seating proof passes", "Tare or capacity state recorded"],
+      "consumables": ["Approved liner or sealed container where the process requires it"], "status": "modeled",
+      "open_questions": ["What maximum bin mass and grip geometry permit accessible removal without spill?"]
+    },
+    {
+      "id": "SVC-002", "component": "Exhaust filter cassette", "service_class": "USER", "access_state": "USER_ACCESS",
+      "tasks": ["Exchange as a sealed cassette", "Inspect gasket and keyed seating", "Route spent cassette according to captured material"],
+      "interval_basis": ["Differential-pressure condition", "Captured-mass or batch limit", "Material-specific maximum time"],
+      "event_triggers": ["Capture loss", "Wet loading", "Tear", "Unknown or hazardous capture"],
+      "return_to_service": ["Cassette identity and rating match manifest", "Seating interlock passes", "Baseline pressure-flow check passes"],
+      "consumables": ["Process-rated sealed filter cassette"], "status": "apparatus_specific_open",
+      "open_questions": ["Which captures make the cassette trained-service rather than user-service?"]
+    },
+    {
+      "id": "SVC-003", "component": "Presentation and quarantine chamber", "service_class": "USER", "access_state": "USER_ACCESS",
+      "tasks": ["Remove intact refused material", "Inspect cleanable surfaces", "Clean using the admitted method"],
+      "interval_basis": ["Every batch", "Visible residue", "Material-change cleaning rule"],
+      "event_triggers": ["Unknown spill", "Biological contamination", "Broken or leaking input"],
+      "return_to_service": ["No trapped inventory", "Required cleanliness status recorded", "Closure and observation channels pass"],
+      "consumables": ["Material-compatible wipes or removable liner"], "status": "modeled",
+      "open_questions": ["Which contamination classes require trained decontamination or replacement?"]
+    },
+    {
+      "id": "SVC-004", "component": "Internal ducts, gates, and screens", "service_class": "TRAINED", "access_state": "SERVICE_LOCKOUT",
+      "tasks": ["Inspect blockage, abrasion, deposits, seals, and actuator linkage", "Recover and assign trapped material", "Clean by the validated dry or wet method"],
+      "interval_basis": ["Condition monitoring", "Operating hours or batches", "Material-change rule"],
+      "event_triggers": ["Jam", "Pressure trip", "Routing disagreement", "Mass-closure failure", "Containment loss"],
+      "return_to_service": ["Isolation released only after reassembly", "Gate motion and position proof pass", "Leak and blank-run checks pass"],
+      "consumables": ["Approved seals", "Cleaning capture media"], "status": "apparatus_specific_open",
+      "open_questions": ["Can duct modules be removed intact to avoid in-place hazardous cleaning?"]
+    },
+    {
+      "id": "SVC-005", "component": "Rotor and high-energy drive assembly", "service_class": "PROTECTED_REPLACE_ONLY", "access_state": "SERVICE_LOCKOUT",
+      "tasks": ["Inspect only under protected procedure", "Replace life-limited or fault-affected module", "Preserve retired part and event provenance where analysis is required"],
+      "interval_basis": ["Operating cycles and hours", "Vibration and temperature trend", "Verified retirement life"],
+      "event_triggers": ["Overspeed", "Severe imbalance", "Impact", "Bearing distress", "Fire or flood", "Containment event"],
+      "return_to_service": ["Correct module and fastener configuration verified", "Containment closed", "No-material and increasing-speed recommissioning passes"],
+      "consumables": ["Manufacturer-controlled rotor, bearings, fasteners, and retention parts"], "status": "apparatus_specific_open",
+      "open_questions": ["Which items are replace-only versus inspectable by trained service?"]
+    },
+    {
+      "id": "SVC-006", "component": "Containment enclosure and guards", "service_class": "PROTECTED_REPLACE_ONLY", "access_state": "SERVICE_LOCKOUT",
+      "tasks": ["Inspect deformation, cracks, fasteners, hinges, locks, and impact evidence", "Replace damaged containment-critical elements"],
+      "interval_basis": ["Pre-run external inspection", "Periodic protected inspection", "Defined service life"],
+      "event_triggers": ["Impact", "Overspeed", "Fragment event", "Tip-over", "Fire", "Unauthorized modification"],
+      "return_to_service": ["Configuration matches containment basis", "Locks and interlocks pass", "Required proof or inspection evidence attached"],
+      "consumables": ["Controlled fasteners, seals, and complete containment modules"], "status": "apparatus_specific_open",
+      "open_questions": ["What damage may be inspected versus requiring automatic retirement?"]
+    },
+    {
+      "id": "SVC-007", "component": "Safety sensors and protective controller", "service_class": "PROTECTED_REPLACE_ONLY", "access_state": "SERVICE_LOCKOUT",
+      "tasks": ["Calibrate or replace sensors", "Verify channel freshness and plausibility", "Apply controlled software or configuration update"],
+      "interval_basis": ["Calibration expiry", "Self-test result", "Configuration revision"],
+      "event_triggers": ["Sensor disagreement", "Watchdog trip", "Data corruption", "Controller restart during operation"],
+      "return_to_service": ["Calibration and identity recorded", "Fault-injection regression passes", "Independent fallback verified"],
+      "consumables": ["Configuration-controlled sensor or controller module"], "status": "apparatus_specific_open",
+      "open_questions": ["Which protective channels require independent third-party calibration?"]
+    },
+    {
+      "id": "SVC-008", "component": "Food-only subsystem boundary", "service_class": "TRAINED", "access_state": "SERVICE_LOCKOUT",
+      "tasks": ["Inspect air, drainage, surface, tool, and storage separation", "Perform process-specific cleaning validation", "Quarantine material after any boundary failure"],
+      "interval_basis": ["Before food-process release", "Material and cleaning schedule", "Boundary-monitoring result"],
+      "event_triggers": ["Routing fault", "Shared-air or drainage indication", "General-recovery residue", "Unknown cleanliness"],
+      "return_to_service": ["Contamination scope bounded", "Cleaning validation passes", "Food-domain authorization independently restored"],
+      "consumables": ["Food-process-specific filters, seals, cleaning materials, and contact parts"], "status": "apparatus_specific_open",
+      "open_questions": ["Can any proposed integrated housing preserve adequate physical isolation?"]
+    },
+    {
+      "id": "SVC-009", "component": "Electrical enclosure, cabling, bonding, and isolation", "service_class": "TRAINED", "access_state": "SERVICE_LOCKOUT",
+      "tasks": ["Inspect damage, ingress, protective devices, grounding, bonding, and isolation", "Perform applicable electrical safety tests"],
+      "interval_basis": ["Jurisdictional requirement", "Condition and operating environment", "Configuration change"],
+      "event_triggers": ["Protection trip", "Moisture ingress", "Fire", "Flood", "Damaged cable", "Unexpected actuation"],
+      "return_to_service": ["Inspection and electrical tests pass", "Enclosure integrity restored", "Power-restoration behavior verified"],
+      "consumables": ["Rated protective devices, glands, cables, seals, and complete modules"], "status": "apparatus_specific_open",
+      "open_questions": ["Which product category and jurisdiction determine the test program?"]
+    },
+    {
+      "id": "SVC-010", "component": "Installation, anchoring, room interface, and emergency controls", "service_class": "TRAINED", "access_state": "SERVICE_LOCKOUT",
+      "tasks": ["Inspect anchoring, clearances, drainage, exhaust, building supply, and emergency access", "Measure transmitted vibration and noise"],
+      "interval_basis": ["Initial installation", "Relocation", "Periodic inspection", "Building modification"],
+      "event_triggers": ["Tip or impact", "Abnormal building vibration", "Flood", "External fire", "Power disturbance"],
+      "return_to_service": ["Installation manifest matches the site", "Anchoring and utilities verified", "Exclusion and emergency access restored"],
+      "consumables": ["Installation-specific anchors, ducts, seals, and labels"], "status": "apparatus_specific_open",
+      "open_questions": ["What installation classes define the domestic deployment envelope?"]
+    }
+  ]
+}

--- a/safety/stop-recovery.json
+++ b/safety/stop-recovery.json
@@ -1,0 +1,76 @@
+{
+  "schema_version": "1.0.0",
+  "matrix_version": "0.1.0",
+  "events": [
+    {
+      "id": "EV-001", "hazards": ["HZ-001"], "trigger": "Vibration exceeds the commissioned magnitude, persistence, or trend limit", "stop_class": "protective",
+      "actions": {"feed": "inhibit", "drive": "controlled_deceleration", "brake": "apparatus_specific", "extraction": "maintain", "cooling": "maintain", "gates": "hold", "alarm": "local_and_remote", "latch": true},
+      "access_release": ["Zero hazardous motion independently verified", "Containment remains intact", "Rotor and load inspected"],
+      "reset_authority": "trained_service", "verification": "Bounded imbalance tests across the admitted speed envelope", "status": "apparatus_specific_open",
+      "open_questions": ["Does braking increase bearing or containment load above a controlled coast?"]
+    },
+    {
+      "id": "EV-002", "hazards": ["HZ-002", "HZ-011"], "trigger": "Overspeed channel trips or speed observations disagree", "stop_class": "emergency",
+      "actions": {"feed": "inhibit", "drive": "remove_torque", "brake": "apparatus_specific", "extraction": "maintain", "cooling": "maintain", "gates": "hold", "alarm": "local_and_remote", "latch": true},
+      "access_release": ["Motion independently verified absent", "Overspeed protection and sensors inspected", "Maximum observed or bounded speed reconciled with containment basis"],
+      "reset_authority": "protected_service", "verification": "Primary-control and speed-sensor fault injection", "status": "apparatus_specific_open",
+      "open_questions": ["What independent energy source operates the selected brake during drive or building-power failure?"]
+    },
+    {
+      "id": "EV-003", "hazards": ["HZ-004", "HZ-008"], "trigger": "Feed motion, torque, airflow, or pressure indicates a jam or blockage", "stop_class": "protective",
+      "actions": {"feed": "inhibit", "drive": "controlled_deceleration", "brake": "apparatus_specific", "extraction": "apparatus_specific", "cooling": "maintain", "gates": "apparatus_specific", "alarm": "local", "latch": true},
+      "access_release": ["Motion and pressure verified safe", "Material position and stored energy bounded", "No-reach clearing method selected"],
+      "reset_authority": "trained_service", "verification": "Deliberate bounded jams and filter or outlet blockages", "status": "apparatus_specific_open",
+      "open_questions": ["Which gate movements relieve the blockage without releasing pressure or material?"]
+    },
+    {
+      "id": "EV-004", "hazards": ["HZ-005", "HZ-007"], "trigger": "Dust capture, filter loading, airflow, or containment evidence becomes invalid", "stop_class": "protective",
+      "actions": {"feed": "inhibit", "drive": "controlled_deceleration", "brake": "apparatus_specific", "extraction": "apparatus_specific", "cooling": "maintain", "gates": "isolate", "alarm": "local_and_remote", "latch": true},
+      "access_release": ["Atmosphere and deposited material assessed", "Capture boundary restored", "Contained cleanup procedure authorized"],
+      "reset_authority": "trained_service", "verification": "Capture-loss, filter-loading, and containment fault tests with nonhazardous surrogate", "status": "apparatus_specific_open",
+      "open_questions": ["When does continued extraction spread a release rather than contain it?"]
+    },
+    {
+      "id": "EV-005", "hazards": ["HZ-006"], "trigger": "Fire, smoke, or rapid abnormal temperature rise", "stop_class": "emergency",
+      "actions": {"feed": "inhibit", "drive": "remove_torque", "brake": "apparatus_specific", "extraction": "apparatus_specific", "cooling": "apparatus_specific", "gates": "isolate", "alarm": "local_and_remote", "latch": true},
+      "access_release": ["Emergency re-entry authority declares the area safe", "Fire cause and affected boundaries identified", "Apparatus recommissioned or retired"],
+      "reset_authority": "protected_service", "verification": "Independently reviewed fire-scenario plan; no live test without appropriate facilities", "status": "apparatus_specific_open",
+      "open_questions": ["Which ventilation and suppression response is compatible with each admitted material and fire location?"]
+    },
+    {
+      "id": "EV-006", "hazards": ["HZ-007"], "trigger": "Collector detaches, closure opens, seal fails, or material appears outside a designated boundary", "stop_class": "emergency",
+      "actions": {"feed": "inhibit", "drive": "controlled_deceleration", "brake": "apparatus_specific", "extraction": "apparatus_specific", "cooling": "maintain", "gates": "isolate", "alarm": "local_and_remote", "latch": true},
+      "access_release": ["Motion and atmosphere verified safe", "Released material characterized", "Boundary repaired and leak-tested"],
+      "reset_authority": "trained_service", "verification": "Deliberate closure, seal, collector, and duct faults using safe surrogate material", "status": "apparatus_specific_open",
+      "open_questions": ["Which single boundary failures require room exclusion or evacuation?"]
+    },
+    {
+      "id": "EV-007", "hazards": ["HZ-010", "HZ-017"], "trigger": "Building power fails or supply becomes invalid during RUN or stopping", "stop_class": "emergency",
+      "actions": {"feed": "inhibit", "drive": "remove_torque", "brake": "apparatus_specific", "extraction": "apparatus_specific", "cooling": "apparatus_specific", "gates": "apparatus_specific", "alarm": "local", "latch": true},
+      "access_release": ["Residual motion and energy independently verified safe", "Power-event history retained", "Protective channels pass restart self-test"],
+      "reset_authority": "trained_service", "verification": "Power interruption at each operating and stop phase", "status": "apparatus_specific_open",
+      "open_questions": ["Which protective functions require stored or independent energy?"]
+    },
+    {
+      "id": "EV-008", "hazards": ["HZ-011", "HZ-012"], "trigger": "Required sensor, controller, actuator feedback, watchdog, or communications becomes unavailable, stale, or implausible", "stop_class": "protective",
+      "actions": {"feed": "inhibit", "drive": "controlled_deceleration", "brake": "apparatus_specific", "extraction": "apparatus_specific", "cooling": "apparatus_specific", "gates": "hold", "alarm": "local_and_remote", "latch": true},
+      "access_release": ["Missing safety evidence restored or independently replaced", "Raw observations and clock quality preserved", "Fault injection repeated after repair"],
+      "reset_authority": "trained_service", "verification": "Missing, frozen, delayed, biased, contradictory, and restarted-channel injection", "status": "apparatus_specific_open",
+      "open_questions": ["Which loss scenarios require immediate torque removal rather than controlled deceleration?"]
+    },
+    {
+      "id": "EV-009", "hazards": ["HZ-013", "HZ-014"], "trigger": "Input or collected material violates its admission or destination contract", "stop_class": "protective",
+      "actions": {"feed": "inhibit", "drive": "controlled_deceleration", "brake": "apparatus_specific", "extraction": "apparatus_specific", "cooling": "apparatus_specific", "gates": "isolate", "alarm": "local", "latch": true},
+      "access_release": ["Affected material quarantined", "Credible hazard and contaminated routes bounded", "Authorized intact diversion or cleanup selected"],
+      "reset_authority": "trained_service", "verification": "Adversarial admission and routing tests without destructive treatment of hazardous specimens", "status": "apparatus_specific_open",
+      "open_questions": ["Which uncertainty classes require external emergency response rather than local quarantine?"]
+    },
+    {
+      "id": "EV-010", "hazards": ["HZ-001", "HZ-003", "HZ-007"], "trigger": "Emergency-stop actuator is used", "stop_class": "emergency",
+      "actions": {"feed": "inhibit", "drive": "remove_torque", "brake": "apparatus_specific", "extraction": "apparatus_specific", "cooling": "apparatus_specific", "gates": "apparatus_specific", "alarm": "local_and_remote", "latch": true},
+      "access_release": ["Cause of emergency-stop use recorded", "All residual hazards independently verified safe", "Event-specific inspection completed"],
+      "reset_authority": "trained_service", "verification": "Emergency stop from every operating phase and under loss of normal control", "status": "apparatus_specific_open",
+      "open_questions": ["Which hazards make immediate energy removal less safe than the protective-stop sequence?"]
+    }
+  ]
+}

--- a/scripts/validate-safety.py
+++ b/scripts/validate-safety.py
@@ -18,6 +18,9 @@ from typing import Any, Iterable
 
 ROOT = Path(__file__).resolve().parents[1]
 HAZARDS = ROOT / "safety" / "hazards.json"
+OPERATING_STATES = ROOT / "safety" / "operating-states.json"
+STOP_RECOVERY = ROOT / "safety" / "stop-recovery.json"
+SERVICE_MAINTENANCE = ROOT / "safety" / "service-maintenance.json"
 MANIFEST_DIR = ROOT / "safety" / "manifests"
 SCHEMA_DIR = ROOT / "safety" / "schemas"
 
@@ -37,6 +40,9 @@ CONTROL_ID = re.compile(r"^CTRL-[0-9]{3}$")
 TRACE_ID = re.compile(r"^TR-[0-9]{3}$")
 DATUM_ID = re.compile(r"^DAT-[A-Z]+-[0-9]{3}$")
 SAFETY_ITEM_ID = re.compile(r"^(SNS|INT)-[0-9]{3}$")
+TRANSITION_ID = re.compile(r"^TX-[0-9]{3}$")
+EVENT_ID = re.compile(r"^EV-[0-9]{3}$")
+SERVICE_ID = re.compile(r"^SVC-[0-9]{3}$")
 
 
 class Problems:
@@ -139,6 +145,126 @@ def validate_hazards(path: Path, problems: Problems) -> None:
             }, tloc, "invalid trace status")
             problems.require(bool(str(trace.get("reference", "")).strip()), tloc,
                              "trace reference must be nonempty")
+
+
+def validate_operating_states(path: Path, problems: Problems) -> None:
+    data = read_json(path, problems)
+    if not isinstance(data, dict):
+        return
+    loc = str(path.relative_to(ROOT))
+    states = data.get("states")
+    problems.require(isinstance(states, list), loc, "states must be an array")
+    state_ids = {
+        item.get("id") for item in states if isinstance(item, dict)
+    } if isinstance(states, list) else set()
+    problems.require(state_ids == STATES, loc, "state set must exactly match the normative vocabulary")
+    for index, state in enumerate(states if isinstance(states, list) else []):
+        sloc = f"{loc}:states[{index}]"
+        problems.require(isinstance(state, dict), sloc, "state must be an object")
+        if isinstance(state, dict):
+            problems.require(bool(str(state.get("invariant", "")).strip()), sloc, "invariant is required")
+            problems.require(bool(str(state.get("access", "")).strip()), sloc, "access rule is required")
+    transitions = data.get("transitions")
+    problems.require(isinstance(transitions, list) and bool(transitions), loc, "transitions must be nonempty")
+    seen: set[str] = set()
+    coverage: set[str] = set()
+    for index, transition in enumerate(transitions if isinstance(transitions, list) else []):
+        tloc = f"{loc}:transitions[{index}]"
+        if not isinstance(transition, dict):
+            problems.errors.append(f"{tloc}: transition must be an object")
+            continue
+        unique_id(transition.get("id"), TRANSITION_ID, seen, tloc, problems)
+        source, target = transition.get("from"), transition.get("to")
+        problems.require(source in STATES or source == "*", tloc, "unknown source state")
+        problems.require(target in STATES, tloc, "unknown target state")
+        if source in STATES:
+            coverage.add(source)
+        for field in ("guards", "actions", "completion_evidence", "ledger"):
+            problems.require(nonempty_strings(transition.get(field)), tloc, f"{field} must be nonempty")
+        problems.require(transition.get("timeout_fallback") in STATES, tloc, "invalid timeout fallback")
+        problems.require(transition.get("reset_authority") in {
+            "automatic", "user", "trained_service", "protected_service",
+        }, tloc, "invalid reset authority")
+    problems.require("RUN" in coverage and "FAULT_LATCHED" in coverage, loc,
+                     "RUN and FAULT_LATCHED require explicit outgoing recovery transitions")
+
+
+def hazard_ids(path: Path, problems: Problems) -> set[str]:
+    data = read_json(path, problems)
+    if not isinstance(data, dict) or not isinstance(data.get("hazards"), list):
+        return set()
+    return {item.get("id") for item in data["hazards"] if isinstance(item, dict)}
+
+
+def validate_stop_recovery(path: Path, known_hazards: set[str], problems: Problems) -> None:
+    data = read_json(path, problems)
+    if not isinstance(data, dict):
+        return
+    loc = str(path.relative_to(ROOT))
+    events = data.get("events")
+    problems.require(isinstance(events, list) and bool(events), loc, "events must be nonempty")
+    seen: set[str] = set()
+    covered: set[str] = set()
+    for index, event in enumerate(events if isinstance(events, list) else []):
+        eloc = f"{loc}:events[{index}]"
+        if not isinstance(event, dict):
+            problems.errors.append(f"{eloc}: event must be an object")
+            continue
+        unique_id(event.get("id"), EVENT_ID, seen, eloc, problems)
+        refs = event.get("hazards")
+        problems.require(nonempty_strings(refs), eloc, "hazards must be nonempty")
+        if isinstance(refs, list):
+            problems.require(set(refs) <= known_hazards, eloc, "event references an unknown hazard")
+            covered.update(refs)
+        actions = event.get("actions")
+        required_actions = {"feed", "drive", "brake", "extraction", "cooling", "gates", "alarm", "latch"}
+        problems.require(isinstance(actions, dict) and set(actions) == required_actions,
+                         eloc, "actions must contain the complete action vocabulary")
+        problems.require(nonempty_strings(event.get("access_release")), eloc,
+                         "access_release must be nonempty")
+        problems.require(event.get("status") in {"modeled", "apparatus_specific_open", "verified"},
+                         eloc, "invalid status")
+        if event.get("status") == "verified":
+            problems.require(not event.get("open_questions"), eloc,
+                             "verified event may not retain open questions")
+    problems.require({"HZ-001", "HZ-002", "HZ-004", "HZ-005", "HZ-006", "HZ-007",
+                      "HZ-008", "HZ-010", "HZ-011", "HZ-012", "HZ-013", "HZ-014",
+                      "HZ-017"} <= covered, loc,
+                     "stop matrix does not cover every hazard requiring an active response")
+
+
+def validate_service_maintenance(path: Path, problems: Problems) -> None:
+    data = read_json(path, problems)
+    if not isinstance(data, dict):
+        return
+    loc = str(path.relative_to(ROOT))
+    components = data.get("components")
+    problems.require(isinstance(components, list) and bool(components), loc,
+                     "components must be nonempty")
+    seen: set[str] = set()
+    classes: set[str] = set()
+    for index, component in enumerate(components if isinstance(components, list) else []):
+        cloc = f"{loc}:components[{index}]"
+        if not isinstance(component, dict):
+            problems.errors.append(f"{cloc}: component must be an object")
+            continue
+        unique_id(component.get("id"), SERVICE_ID, seen, cloc, problems)
+        service_class = component.get("service_class")
+        classes.add(service_class)
+        problems.require(service_class in {"USER", "TRAINED", "PROTECTED_REPLACE_ONLY"},
+                         cloc, "invalid service class")
+        expected_access = "USER_ACCESS" if service_class == "USER" else "SERVICE_LOCKOUT"
+        problems.require(component.get("access_state") == expected_access, cloc,
+                         "access state is inconsistent with service class")
+        for field in ("tasks", "interval_basis", "return_to_service"):
+            problems.require(nonempty_strings(component.get(field)), cloc, f"{field} must be nonempty")
+        problems.require(component.get("status") in {"modeled", "apparatus_specific_open", "verified"},
+                         cloc, "invalid status")
+        if component.get("status") == "verified":
+            problems.require(not component.get("open_questions"), cloc,
+                             "verified component may not retain open questions")
+    problems.require(classes == {"USER", "TRAINED", "PROTECTED_REPLACE_ONLY"}, loc,
+                     "register must exercise all service classes")
 
 
 def manifest_readiness(data: dict[str, Any]) -> list[str]:
@@ -260,6 +386,10 @@ def main(argv: list[str] | None = None) -> int:
     for schema in sorted(SCHEMA_DIR.glob("*.json")):
         read_json(schema, problems)
     validate_hazards(HAZARDS, problems)
+    validate_operating_states(OPERATING_STATES, problems)
+    known_hazards = hazard_ids(HAZARDS, problems)
+    validate_stop_recovery(STOP_RECOVERY, known_hazards, problems)
+    validate_service_maintenance(SERVICE_MAINTENANCE, problems)
     paths = manifest_paths(args.manifests)
     problems.require(bool(paths), "safety/manifests", "no manifests found")
     for path in paths:

--- a/tests/test_validate_safety.py
+++ b/tests/test_validate_safety.py
@@ -15,6 +15,20 @@ SPEC.loader.exec_module(validator)
 
 
 class SafetyValidatorTests(unittest.TestCase):
+    def test_operating_stop_and_service_records_are_valid(self):
+        problems = validator.Problems()
+        validator.validate_operating_states(
+            ROOT / "safety" / "operating-states.json", problems
+        )
+        hazards = validator.hazard_ids(ROOT / "safety" / "hazards.json", problems)
+        validator.validate_stop_recovery(
+            ROOT / "safety" / "stop-recovery.json", hazards, problems
+        )
+        validator.validate_service_maintenance(
+            ROOT / "safety" / "service-maintenance.json", problems
+        )
+        self.assertEqual([], problems.errors)
+
     def test_repository_records_are_structurally_valid_but_blocked(self):
         problems = validator.Problems()
         validator.validate_hazards(ROOT / "safety" / "hazards.json", problems)


### PR DESCRIPTION
## Summary

Continues the implementation of #9 after the safety foundation merged in #12.

This change adds:

- a nine-state machine-readable operating model with guarded transitions, timeout fallbacks, reset authority, and physical/epistemic ledger requirements;
- an event-specific stop and recovery matrix for imbalance, overspeed, jams, dust, fire, containment loss, power failure, instrumentation faults, inadmissible material, and emergency-stop use;
- a service and maintenance register separating user, trained, and protected replace-only work;
- JSON Schemas for all three record families;
- validator checks for state vocabulary and transition coverage, hazard references and active-response coverage, service/access consistency, unique identifiers, and verified-record semantics.

The state model prevents automatic restoration of RUN after power or controller recovery. The stop matrix leaves braking, extraction, cooling, and gate decisions apparatus-specific where choosing blindly could increase danger. The service register keeps the rotor, containment enclosure, and protective controller outside ordinary user repair.

## Validation

- `python3 scripts/validate-safety.py`
- `python3 -m unittest discover -s tests -v`
- Four tests pass.
- The Experiment 001 manifest remains structurally valid and explicitly `BLOCKED`.
- The runnable gate continues to reject the uncommissioned apparatus.

## Issue

Advances #9. Cleaning and accessibility records, installation requirements, apparatus-specific thresholds, protective-function tests, commissioning evidence, and generated readable views remain open.