### PR TITLE
Strengthen Experiment 001 safety manifest

### DIFF
--- a/docs/safety-maintenance-spec.md
+++ b/docs/safety-maintenance-spec.md
@@ -151,6 +151,23 @@ To require a manifest to be admitted for operation rather than merely valid as a
 
 The checked-in Experiment 001 manifest is intentionally blocked until apparatus-specific values and verification evidence exist. A successful structural validation must not convert those unknowns into permission to run.
 
+For Experiment 001, structural completeness includes the complete, versioned
+datum-ID inventory enforced by the validator. Removing a required datum is a
+validation failure rather than a way to make an unknown disappear. A datum
+with a physical unit requires a recorded tolerance before it can contribute to
+RUN readiness. Every required safety sensor shall identify its instrument and
+installed location, range, accuracy, sampling rate, calibration interval and
+record, plausibility test, and current-availability test. Expired calibration
+is a refusal condition. Every required interlock shall identify an independent
+fallback so that a software interpretation is not the sole protection against
+a high-consequence event.
+
+RUN authorization remains a separate admission act after the evidence record
+is complete. It shall identify the authority, timestamp, exact authorized
+scope, and evidence record. Setting `approved_for_run` without that record, or
+while any datum, sensor, interlock, calibration, fallback, or explicit blocker
+remains unresolved, shall fail the runnable validation gate.
+
 ## 14. Reference constraints
 
 The following sources establish constraints used by the architecture; their presence does not itself establish conformity:

--- a/safety/README.md
+++ b/safety/README.md
@@ -10,6 +10,17 @@ Experiment 001 apparatus: **BLOCKED**
 Evidence status: **M**  
 Recorded blockers: **6**
 
+## Experiment 001 manifest readiness
+
+The manifest is fail-closed: every required datum must be present and verified; numeric values require tolerances; required sensors require current calibration, plausibility, and availability evidence; required interlocks require an independent fallback; and RUN requires separately recorded authorization.
+
+| Evidence class | Verified | Required | Current result |
+| --- | --- | --- | --- |
+| Apparatus data | 0 | 51 | BLOCKED |
+| Safety sensors | 0 | 5 | BLOCKED |
+| Protective interlocks | 0 | 5 | BLOCKED |
+| Run authorization | 0 | 1 | BLOCKED |
+
 ## Hazard register
 
 | ID | Hazard | Severity | Evidence | Controls | Open questions |

--- a/safety/manifests/experiment-001.json
+++ b/safety/manifests/experiment-001.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0.0",
-  "manifest_version": "0.1.0",
+  "manifest_version": "0.2.0",
   "apparatus_id": "fast-solids-lab-apparatus-unassigned",
   "configuration_id": "experiment-001-precommissioning",
   "intended_process": "Air-assisted classification of characterized polystyrene pellets, coarse salt, and steel BBs",
@@ -15,7 +15,10 @@
         {"id": "DAT-MECH-003", "name": "rotating assembly inertia", "status": "unknown", "value": null, "unit": "kg m^2", "tolerance": null, "provenance": null, "verified_at": null, "evidence": null},
         {"id": "DAT-MECH-004", "name": "maximum credible stored rotational energy", "status": "unknown", "value": null, "unit": "J", "tolerance": null, "provenance": null, "verified_at": null, "evidence": null},
         {"id": "DAT-MECH-005", "name": "vibration protective-stop threshold", "status": "unknown", "value": null, "unit": null, "tolerance": null, "provenance": null, "verified_at": null, "evidence": null},
-        {"id": "DAT-MECH-006", "name": "steel BB retention basis at maximum credible impact", "status": "unknown", "value": null, "unit": null, "tolerance": null, "provenance": null, "verified_at": null, "evidence": null}
+        {"id": "DAT-MECH-006", "name": "steel BB retention basis at maximum credible impact", "status": "unknown", "value": null, "unit": null, "tolerance": null, "provenance": null, "verified_at": null, "evidence": null},
+        {"id": "DAT-MECH-007", "name": "effective maximum radius and tip-speed calculation", "status": "unknown", "value": null, "unit": "m", "tolerance": null, "provenance": null, "verified_at": null, "evidence": null},
+        {"id": "DAT-MECH-008", "name": "commissioned vibration baseline", "status": "unknown", "value": null, "unit": null, "tolerance": null, "provenance": null, "verified_at": null, "evidence": null},
+        {"id": "DAT-MECH-009", "name": "rotor, shaft, bearing, fastener, chamber and guard ratings", "status": "unknown", "value": null, "unit": null, "tolerance": null, "provenance": null, "verified_at": null, "evidence": null}
       ]
     },
     "air_pressure": {
@@ -24,7 +27,10 @@
         {"id": "DAT-AIR-001", "name": "admitted airflow range", "status": "unknown", "value": null, "unit": "m^3/s", "tolerance": null, "provenance": null, "verified_at": null, "evidence": null},
         {"id": "DAT-AIR-002", "name": "filter differential-pressure stop limit", "status": "unknown", "value": null, "unit": "Pa", "tolerance": null, "provenance": null, "verified_at": null, "evidence": null},
         {"id": "DAT-AIR-003", "name": "maximum chamber pressure and vacuum", "status": "unknown", "value": null, "unit": "Pa", "tolerance": null, "provenance": null, "verified_at": null, "evidence": null},
-        {"id": "DAT-AIR-004", "name": "minimum extraction required during stop", "status": "unknown", "value": null, "unit": "m^3/s", "tolerance": null, "provenance": null, "verified_at": null, "evidence": null}
+        {"id": "DAT-AIR-004", "name": "minimum extraction required during stop", "status": "unknown", "value": null, "unit": "m^3/s", "tolerance": null, "provenance": null, "verified_at": null, "evidence": null},
+        {"id": "DAT-AIR-005", "name": "blockage indication threshold and persistence", "status": "unknown", "value": null, "unit": null, "tolerance": null, "provenance": null, "verified_at": null, "evidence": null},
+        {"id": "DAT-AIR-006", "name": "relief behavior, capacity and safe destination", "status": "unknown", "value": null, "unit": null, "tolerance": null, "provenance": null, "verified_at": null, "evidence": null},
+        {"id": "DAT-AIR-007", "name": "collector-detachment and containment-loss detection", "status": "unknown", "value": null, "unit": null, "tolerance": null, "provenance": null, "verified_at": null, "evidence": null}
       ]
     },
     "thermal": {
@@ -32,7 +38,10 @@
       "data": [
         {"id": "DAT-THERM-001", "name": "bearing protective-stop temperature", "status": "unknown", "value": null, "unit": "degC", "tolerance": null, "provenance": null, "verified_at": null, "evidence": null},
         {"id": "DAT-THERM-002", "name": "motor protective-stop temperature", "status": "unknown", "value": null, "unit": "degC", "tolerance": null, "provenance": null, "verified_at": null, "evidence": null},
-        {"id": "DAT-THERM-003", "name": "accessible-surface release temperature", "status": "unknown", "value": null, "unit": "degC", "tolerance": null, "provenance": null, "verified_at": null, "evidence": null}
+        {"id": "DAT-THERM-003", "name": "accessible-surface release temperature", "status": "unknown", "value": null, "unit": "degC", "tolerance": null, "provenance": null, "verified_at": null, "evidence": null},
+        {"id": "DAT-THERM-004", "name": "air-stream protective-stop temperature", "status": "unknown", "value": null, "unit": "degC", "tolerance": null, "provenance": null, "verified_at": null, "evidence": null},
+        {"id": "DAT-THERM-005", "name": "material protective-stop temperature", "status": "unknown", "value": null, "unit": "degC", "tolerance": null, "provenance": null, "verified_at": null, "evidence": null},
+        {"id": "DAT-THERM-006", "name": "filter and electronics protective-stop temperatures", "status": "unknown", "value": null, "unit": "degC", "tolerance": null, "provenance": null, "verified_at": null, "evidence": null}
       ]
     },
     "electrical": {
@@ -40,7 +49,10 @@
       "data": [
         {"id": "DAT-ELEC-001", "name": "supply and protective-device specification", "status": "unknown", "value": null, "unit": null, "tolerance": null, "provenance": null, "verified_at": null, "evidence": null},
         {"id": "DAT-ELEC-002", "name": "grounding and bonding verification", "status": "unknown", "value": null, "unit": null, "tolerance": null, "provenance": null, "verified_at": null, "evidence": null},
-        {"id": "DAT-ELEC-003", "name": "behavior after power loss and restoration", "status": "provisional", "value": "RUN prohibited; enter FAULT_LATCHED until controlled reset", "unit": null, "tolerance": null, "provenance": "docs/safety-maintenance-spec.md#5-operating-states", "verified_at": null, "evidence": null}
+        {"id": "DAT-ELEC-003", "name": "behavior after power loss and restoration", "status": "provisional", "value": "RUN prohibited; enter FAULT_LATCHED until controlled reset", "unit": null, "tolerance": null, "provenance": "docs/safety-maintenance-spec.md#5-operating-states", "verified_at": null, "evidence": null},
+        {"id": "DAT-ELEC-004", "name": "ignition-source review", "status": "unknown", "value": null, "unit": null, "tolerance": null, "provenance": null, "verified_at": null, "evidence": null},
+        {"id": "DAT-ELEC-005", "name": "measured protective bonding and grounding results", "status": "unknown", "value": null, "unit": null, "tolerance": null, "provenance": null, "verified_at": null, "evidence": null},
+        {"id": "DAT-ELEC-006", "name": "electrical isolation points and verification method", "status": "unknown", "value": null, "unit": null, "tolerance": null, "provenance": null, "verified_at": null, "evidence": null}
       ]
     },
     "material": {
@@ -49,7 +61,10 @@
         {"id": "DAT-MAT-001", "name": "admitted material batch identifiers", "status": "unknown", "value": null, "unit": null, "tolerance": null, "provenance": null, "verified_at": null, "evidence": null},
         {"id": "DAT-MAT-002", "name": "steel BB diameter and individual mass range", "status": "unknown", "value": null, "unit": null, "tolerance": null, "provenance": null, "verified_at": null, "evidence": null},
         {"id": "DAT-MAT-003", "name": "particle size and total admitted mass limits", "status": "unknown", "value": null, "unit": null, "tolerance": null, "provenance": null, "verified_at": null, "evidence": null},
-        {"id": "DAT-MAT-004", "name": "dust and ignition-source assessment", "status": "unknown", "value": null, "unit": null, "tolerance": null, "provenance": null, "verified_at": null, "evidence": null}
+        {"id": "DAT-MAT-004", "name": "dust and ignition-source assessment", "status": "unknown", "value": null, "unit": null, "tolerance": null, "provenance": null, "verified_at": null, "evidence": null},
+        {"id": "DAT-MAT-005", "name": "batch moisture range", "status": "unknown", "value": null, "unit": "%", "tolerance": null, "provenance": null, "verified_at": null, "evidence": null},
+        {"id": "DAT-MAT-006", "name": "fines, abrasion and impact constraints", "status": "unknown", "value": null, "unit": null, "tolerance": null, "provenance": null, "verified_at": null, "evidence": null},
+        {"id": "DAT-MAT-007", "name": "per-material and total admitted mass limits", "status": "unknown", "value": null, "unit": "kg", "tolerance": null, "provenance": null, "verified_at": null, "evidence": null}
       ]
     },
     "stop_behavior": {
@@ -57,7 +72,12 @@
       "data": [
         {"id": "DAT-STOP-001", "name": "normal coast-down time", "status": "unknown", "value": null, "unit": "s", "tolerance": null, "provenance": null, "verified_at": null, "evidence": null},
         {"id": "DAT-STOP-002", "name": "imbalance safe-stop sequence and response-time budget", "status": "unknown", "value": null, "unit": null, "tolerance": null, "provenance": null, "verified_at": null, "evidence": null},
-        {"id": "DAT-STOP-003", "name": "blockage safe-stop sequence", "status": "unknown", "value": null, "unit": null, "tolerance": null, "provenance": null, "verified_at": null, "evidence": null}
+        {"id": "DAT-STOP-003", "name": "blockage safe-stop sequence", "status": "unknown", "value": null, "unit": null, "tolerance": null, "provenance": null, "verified_at": null, "evidence": null},
+        {"id": "DAT-STOP-004", "name": "overspeed safe-stop sequence and response-time budget", "status": "unknown", "value": null, "unit": null, "tolerance": null, "provenance": null, "verified_at": null, "evidence": null},
+        {"id": "DAT-STOP-005", "name": "feed-jam safe-stop sequence", "status": "unknown", "value": null, "unit": null, "tolerance": null, "provenance": null, "verified_at": null, "evidence": null},
+        {"id": "DAT-STOP-006", "name": "collector-detachment or containment-loss safe-stop sequence", "status": "unknown", "value": null, "unit": null, "tolerance": null, "provenance": null, "verified_at": null, "evidence": null},
+        {"id": "DAT-STOP-007", "name": "sensor-loss or disagreement safe-stop sequence", "status": "unknown", "value": null, "unit": null, "tolerance": null, "provenance": null, "verified_at": null, "evidence": null},
+        {"id": "DAT-STOP-008", "name": "power-loss-during-stop behavior", "status": "unknown", "value": null, "unit": null, "tolerance": null, "provenance": null, "verified_at": null, "evidence": null}
       ]
     },
     "access_service": {
@@ -65,7 +85,9 @@
       "data": [
         {"id": "DAT-ACCESS-001", "name": "guard unlock conditions", "status": "unknown", "value": null, "unit": null, "tolerance": null, "provenance": null, "verified_at": null, "evidence": null},
         {"id": "DAT-ACCESS-002", "name": "hazardous-energy isolation and verification procedure", "status": "unknown", "value": null, "unit": null, "tolerance": null, "provenance": null, "verified_at": null, "evidence": null},
-        {"id": "DAT-ACCESS-003", "name": "post-trip inspection and reset authority", "status": "unknown", "value": null, "unit": null, "tolerance": null, "provenance": null, "verified_at": null, "evidence": null}
+        {"id": "DAT-ACCESS-003", "name": "post-trip inspection and reset authority", "status": "unknown", "value": null, "unit": null, "tolerance": null, "provenance": null, "verified_at": null, "evidence": null},
+        {"id": "DAT-ACCESS-004", "name": "independent zero-speed and residual-hazard verification", "status": "unknown", "value": null, "unit": null, "tolerance": null, "provenance": null, "verified_at": null, "evidence": null},
+        {"id": "DAT-ACCESS-005", "name": "post-service reassembly and recommissioning test", "status": "unknown", "value": null, "unit": null, "tolerance": null, "provenance": null, "verified_at": null, "evidence": null}
       ]
     },
     "installation": {
@@ -78,19 +100,20 @@
     }
   },
   "required_sensors": [
-    {"id": "SNS-001", "name": "rotor or imposed-swirl speed", "required": true, "status": "missing", "verification": null},
-    {"id": "SNS-002", "name": "vibration", "required": true, "status": "missing", "verification": null},
-    {"id": "SNS-003", "name": "bearing and process temperature", "required": true, "status": "missing", "verification": null},
-    {"id": "SNS-004", "name": "airflow and pressure", "required": true, "status": "missing", "verification": null},
-    {"id": "SNS-005", "name": "guard, collector, and service-closure state", "required": true, "status": "missing", "verification": null}
+    {"id": "SNS-001", "name": "rotor or imposed-swirl speed", "required": true, "status": "missing", "verification": null, "instrument_id": null, "location": null, "range": null, "accuracy": null, "sample_rate_hz": null, "calibrated_at": null, "calibration_due_at": null, "calibration_record": null, "plausibility_test": null, "availability_test": null},
+    {"id": "SNS-002", "name": "vibration", "required": true, "status": "missing", "verification": null, "instrument_id": null, "location": null, "range": null, "accuracy": null, "sample_rate_hz": null, "calibrated_at": null, "calibration_due_at": null, "calibration_record": null, "plausibility_test": null, "availability_test": null},
+    {"id": "SNS-003", "name": "bearing and process temperature", "required": true, "status": "missing", "verification": null, "instrument_id": null, "location": null, "range": null, "accuracy": null, "sample_rate_hz": null, "calibrated_at": null, "calibration_due_at": null, "calibration_record": null, "plausibility_test": null, "availability_test": null},
+    {"id": "SNS-004", "name": "airflow and pressure", "required": true, "status": "missing", "verification": null, "instrument_id": null, "location": null, "range": null, "accuracy": null, "sample_rate_hz": null, "calibrated_at": null, "calibration_due_at": null, "calibration_record": null, "plausibility_test": null, "availability_test": null},
+    {"id": "SNS-005", "name": "guard, collector, and service-closure state", "required": true, "status": "missing", "verification": null, "instrument_id": null, "location": null, "range": null, "accuracy": null, "sample_rate_hz": null, "calibrated_at": null, "calibration_due_at": null, "calibration_record": null, "plausibility_test": null, "availability_test": null}
   ],
   "required_interlocks": [
-    {"id": "INT-001", "name": "feed inhibited without closed containment", "required": true, "status": "missing", "verification": null},
-    {"id": "INT-002", "name": "guard retained until residual hazards are verified safe", "required": true, "status": "missing", "verification": null},
-    {"id": "INT-003", "name": "independent overspeed protection", "required": true, "status": "missing", "verification": null},
-    {"id": "INT-004", "name": "restart inhibited after power restoration or protective trip", "required": true, "status": "missing", "verification": null},
-    {"id": "INT-005", "name": "required sensor unavailable or stale prevents RUN", "required": true, "status": "missing", "verification": null}
+    {"id": "INT-001", "name": "feed inhibited without closed containment", "required": true, "status": "missing", "verification": null, "independent_fallback": null},
+    {"id": "INT-002", "name": "guard retained until residual hazards are verified safe", "required": true, "status": "missing", "verification": null, "independent_fallback": null},
+    {"id": "INT-003", "name": "independent overspeed protection", "required": true, "status": "missing", "verification": null, "independent_fallback": null},
+    {"id": "INT-004", "name": "restart inhibited after power restoration or protective trip", "required": true, "status": "missing", "verification": null, "independent_fallback": null},
+    {"id": "INT-005", "name": "required sensor unavailable or stale prevents RUN", "required": true, "status": "missing", "verification": null, "independent_fallback": null}
   ],
+  "run_authorization": {"authority": null, "authorized_at": null, "scope": null, "evidence": null},
   "blockers": [
     "No physical apparatus or immutable configuration identifier has been supplied.",
     "Mechanical speed, energy, imbalance, and retention limits are unset.",

--- a/safety/schemas/apparatus-manifest.schema.json
+++ b/safety/schemas/apparatus-manifest.schema.json
@@ -7,7 +7,7 @@
   "required": [
     "schema_version", "manifest_version", "apparatus_id", "configuration_id",
     "intended_process", "evidence_status", "approved_for_run", "categories",
-    "required_sensors", "required_interlocks", "blockers"
+    "required_sensors", "required_interlocks", "run_authorization", "blockers"
   ],
   "properties": {
     "schema_version": {"const": "1.0.0"},
@@ -34,6 +34,16 @@
     },
     "required_sensors": {"type": "array", "items": {"$ref": "#/$defs/safety_item"}},
     "required_interlocks": {"type": "array", "items": {"$ref": "#/$defs/safety_item"}},
+    "run_authorization": {
+      "type": "object", "additionalProperties": false,
+      "required": ["authority", "authorized_at", "scope", "evidence"],
+      "properties": {
+        "authority": {"type": ["string", "null"]},
+        "authorized_at": {"type": ["string", "null"], "format": "date-time"},
+        "scope": {"type": ["string", "null"]},
+        "evidence": {"type": ["string", "null"]}
+      }
+    },
     "blockers": {"type": "array", "items": {"type": "string", "minLength": 1}}
   },
   "$defs": {
@@ -71,7 +81,18 @@
         "name": {"type": "string", "minLength": 1},
         "required": {"type": "boolean"},
         "status": {"enum": ["missing", "installed", "verified", "not_applicable"]},
-        "verification": {"type": ["string", "null"]}
+        "verification": {"type": ["string", "null"]},
+        "instrument_id": {"type": ["string", "null"]},
+        "location": {"type": ["string", "null"]},
+        "range": {"type": ["string", "null"]},
+        "accuracy": {"type": ["string", "null"]},
+        "sample_rate_hz": {"type": ["number", "null"], "exclusiveMinimum": 0},
+        "calibrated_at": {"type": ["string", "null"], "format": "date-time"},
+        "calibration_due_at": {"type": ["string", "null"], "format": "date-time"},
+        "calibration_record": {"type": ["string", "null"]},
+        "plausibility_test": {"type": ["string", "null"]},
+        "availability_test": {"type": ["string", "null"]},
+        "independent_fallback": {"type": ["string", "null"]}
       }
     }
   }

--- a/scripts/render-safety.py
+++ b/scripts/render-safety.py
@@ -37,6 +37,16 @@ def render() -> str:
     service = load("service-maintenance.json")
     domestic = load("domestic-boundaries.json")
     manifest = load("manifests/experiment-001.json")
+    manifest_data = [
+        datum
+        for category in manifest["categories"].values()
+        for datum in category["data"]
+    ]
+    verified_data = sum(datum["status"] == "verified" for datum in manifest_data)
+    verified_sensors = sum(item["status"] == "verified"
+                           for item in manifest["required_sensors"] if item["required"])
+    verified_interlocks = sum(item["status"] == "verified"
+                              for item in manifest["required_interlocks"] if item["required"])
 
     lines = [
         "# Centerfuge Safety Records",
@@ -51,6 +61,33 @@ def render() -> str:
         f"Experiment 001 apparatus: **{'RUNNABLE' if manifest['approved_for_run'] else 'BLOCKED'}**  ",
         f"Evidence status: **{manifest['evidence_status']}**  ",
         f"Recorded blockers: **{len(manifest['blockers'])}**",
+        "",
+        "## Experiment 001 manifest readiness",
+        "",
+        "The manifest is fail-closed: every required datum must be present and verified; "
+        "numeric values require tolerances; required sensors require current calibration, "
+        "plausibility, and availability evidence; required interlocks require an independent "
+        "fallback; and RUN requires separately recorded authorization.",
+        "",
+    ]
+    lines += table(
+        ["Evidence class", "Verified", "Required", "Current result"],
+        [
+            ["Apparatus data", str(verified_data), str(len(manifest_data)),
+             "PASS" if verified_data == len(manifest_data) else "BLOCKED"],
+            ["Safety sensors", str(verified_sensors), str(sum(
+                item["required"] for item in manifest["required_sensors"])),
+             "PASS" if verified_sensors == sum(
+                 item["required"] for item in manifest["required_sensors"]) else "BLOCKED"],
+            ["Protective interlocks", str(verified_interlocks), str(sum(
+                item["required"] for item in manifest["required_interlocks"])),
+             "PASS" if verified_interlocks == sum(
+                 item["required"] for item in manifest["required_interlocks"]) else "BLOCKED"],
+            ["Run authorization", "1" if all(manifest["run_authorization"].values()) else "0",
+             "1", "PASS" if all(manifest["run_authorization"].values()) else "BLOCKED"],
+        ],
+    )
+    lines += [
         "",
         "## Hazard register",
         "",

--- a/scripts/validate-safety.py
+++ b/scripts/validate-safety.py
@@ -9,6 +9,7 @@ shape; these checks enforce repository invariants and readiness semantics.
 from __future__ import annotations
 
 import argparse
+from datetime import datetime, timezone
 import json
 import re
 import sys
@@ -33,6 +34,38 @@ STATES = {
 CATEGORIES = {
     "mechanical", "air_pressure", "thermal", "electrical", "material",
     "stop_behavior", "access_service", "installation",
+}
+EXPERIMENT_001_REQUIRED_DATA = {
+    "mechanical": {
+        "DAT-MECH-001", "DAT-MECH-002", "DAT-MECH-003", "DAT-MECH-004",
+        "DAT-MECH-005", "DAT-MECH-006", "DAT-MECH-007", "DAT-MECH-008",
+        "DAT-MECH-009",
+    },
+    "air_pressure": {
+        "DAT-AIR-001", "DAT-AIR-002", "DAT-AIR-003", "DAT-AIR-004",
+        "DAT-AIR-005", "DAT-AIR-006", "DAT-AIR-007",
+    },
+    "thermal": {
+        "DAT-THERM-001", "DAT-THERM-002", "DAT-THERM-003",
+        "DAT-THERM-004", "DAT-THERM-005", "DAT-THERM-006",
+    },
+    "electrical": {
+        "DAT-ELEC-001", "DAT-ELEC-002", "DAT-ELEC-003",
+        "DAT-ELEC-004", "DAT-ELEC-005", "DAT-ELEC-006",
+    },
+    "material": {
+        "DAT-MAT-001", "DAT-MAT-002", "DAT-MAT-003", "DAT-MAT-004",
+        "DAT-MAT-005", "DAT-MAT-006", "DAT-MAT-007",
+    },
+    "stop_behavior": {
+        "DAT-STOP-001", "DAT-STOP-002", "DAT-STOP-003", "DAT-STOP-004",
+        "DAT-STOP-005", "DAT-STOP-006", "DAT-STOP-007", "DAT-STOP-008",
+    },
+    "access_service": {
+        "DAT-ACCESS-001", "DAT-ACCESS-002", "DAT-ACCESS-003",
+        "DAT-ACCESS-004", "DAT-ACCESS-005",
+    },
+    "installation": {"DAT-INST-001", "DAT-INST-002", "DAT-INST-003"},
 }
 DATUM_STATES = {"unknown", "provisional", "verified", "not_applicable"}
 ITEM_STATES = {"missing", "installed", "verified", "not_applicable"}
@@ -335,12 +368,36 @@ def manifest_readiness(data: dict[str, Any]) -> list[str]:
             for field in ("value", "provenance", "verified_at", "evidence"):
                 if datum.get(field) is None or datum.get(field) == "":
                     blockers.append(f"{datum.get('id', name)}: {field} is missing")
+            if datum.get("status") == "verified" and datum.get("unit") is not None \
+                    and datum.get("tolerance") is None:
+                blockers.append(f"{datum.get('id', name)}: tolerance is missing")
     for collection in ("required_sensors", "required_interlocks"):
         for item in data.get(collection, []):
             if item.get("required") and item.get("status") != "verified":
                 blockers.append(f"{item.get('id', collection)}: required item is not verified")
             if item.get("required") and not item.get("verification"):
                 blockers.append(f"{item.get('id', collection)}: verification reference is missing")
+            if collection == "required_sensors" and item.get("required"):
+                for field in ("instrument_id", "location", "range", "accuracy",
+                              "sample_rate_hz", "calibrated_at", "calibration_due_at",
+                              "calibration_record", "plausibility_test", "availability_test"):
+                    if item.get(field) in (None, ""):
+                        blockers.append(f"{item.get('id', collection)}: {field} is missing")
+                due = item.get("calibration_due_at")
+                if due:
+                    try:
+                        deadline = datetime.fromisoformat(due.replace("Z", "+00:00"))
+                        if deadline <= datetime.now(timezone.utc):
+                            blockers.append(f"{item.get('id', collection)}: calibration is stale")
+                    except (TypeError, ValueError):
+                        blockers.append(f"{item.get('id', collection)}: calibration_due_at is invalid")
+            if collection == "required_interlocks" and item.get("required") \
+                    and not item.get("independent_fallback"):
+                blockers.append(f"{item.get('id', collection)}: independent fallback is missing")
+    authorization = data.get("run_authorization", {})
+    for field in ("authority", "authorized_at", "scope", "evidence"):
+        if not authorization.get(field):
+            blockers.append(f"run_authorization: {field} is missing")
     blockers.extend(str(item) for item in data.get("blockers", []))
     return blockers
 
@@ -353,7 +410,7 @@ def validate_manifest(path: Path, problems: Problems, require_runnable: bool) ->
     required = {
         "schema_version", "manifest_version", "apparatus_id", "configuration_id",
         "intended_process", "evidence_status", "approved_for_run", "categories",
-        "required_sensors", "required_interlocks", "blockers",
+        "required_sensors", "required_interlocks", "run_authorization", "blockers",
     }
     problems.require(not (required - data.keys()), loc,
                      f"missing fields: {', '.join(sorted(required - data.keys()))}")
@@ -391,6 +448,12 @@ def validate_manifest(path: Path, problems: Problems, require_runnable: bool) ->
                 if status == "unknown":
                     problems.require(datum.get("value") is None, dloc,
                                      "unknown datum must not carry a value")
+            present = {entry.get("id") for entry in entries if isinstance(entry, dict)}
+            required_ids = EXPERIMENT_001_REQUIRED_DATA.get(name, set())
+            missing_ids = required_ids - present
+            problems.require(not missing_ids, cloc,
+                             "omits required Experiment 001 data: "
+                             + ", ".join(sorted(missing_ids)))
         seen_items: set[str] = set()
         for collection in ("required_sensors", "required_interlocks"):
             items = data.get(collection)
@@ -406,6 +469,21 @@ def validate_manifest(path: Path, problems: Problems, require_runnable: bool) ->
                 if item.get("status") == "verified":
                     problems.require(bool(item.get("verification")), iloc,
                                      "verified item requires verification reference")
+                if collection == "required_sensors":
+                    for field in ("instrument_id", "location", "range", "accuracy",
+                                  "sample_rate_hz", "calibrated_at", "calibration_due_at",
+                                  "calibration_record", "plausibility_test", "availability_test"):
+                        problems.require(field in item, iloc, f"sensor record requires {field}")
+                else:
+                    problems.require("independent_fallback" in item, iloc,
+                                     "interlock record requires independent_fallback")
+
+    authorization = data.get("run_authorization")
+    problems.require(isinstance(authorization, dict), loc,
+                     "run_authorization must be an object")
+    if isinstance(authorization, dict):
+        problems.require(set(authorization) == {"authority", "authorized_at", "scope", "evidence"},
+                         loc, "run_authorization has the wrong field set")
 
     readiness = manifest_readiness(data)
     approved = data.get("approved_for_run") is True

--- a/tests/test_validate_safety.py
+++ b/tests/test_validate_safety.py
@@ -77,6 +77,57 @@ class SafetyValidatorTests(unittest.TestCase):
         )
         self.assertTrue(any("not admitted for RUN" in error for error in problems.errors))
 
+    def test_required_experiment_datum_cannot_be_omitted(self):
+        source = json.loads(
+            (ROOT / "safety" / "manifests" / "experiment-001.json").read_text()
+        )
+        source["categories"]["mechanical"]["data"] = [
+            datum for datum in source["categories"]["mechanical"]["data"]
+            if datum["id"] != "DAT-MECH-007"
+        ]
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "omitted.json"
+            path.write_text(json.dumps(source), encoding="utf-8")
+            problems = validator.Problems()
+            validator.validate_manifest(path, problems, require_runnable=False)
+        self.assertTrue(any("DAT-MECH-007" in error and "omits required" in error
+                            for error in problems.errors))
+
+    def test_sensor_record_requires_calibration_fields(self):
+        source = json.loads(
+            (ROOT / "safety" / "manifests" / "experiment-001.json").read_text()
+        )
+        del source["required_sensors"][0]["calibration_due_at"]
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "missing-calibration-field.json"
+            path.write_text(json.dumps(source), encoding="utf-8")
+            problems = validator.Problems()
+            validator.validate_manifest(path, problems, require_runnable=False)
+        self.assertTrue(any("sensor record requires calibration_due_at" in error
+                            for error in problems.errors))
+
+    def test_stale_calibration_is_a_readiness_blocker(self):
+        source = json.loads(
+            (ROOT / "safety" / "manifests" / "experiment-001.json").read_text()
+        )
+        sensor = source["required_sensors"][0]
+        sensor.update({
+            "status": "verified",
+            "verification": "tests/evidence/sns-001.json",
+            "instrument_id": "tachometer-example",
+            "location": "drive shaft",
+            "range": "0 to 100 rad/s",
+            "accuracy": "+/- 1 rad/s",
+            "sample_rate_hz": 100,
+            "calibrated_at": "2020-01-01T00:00:00Z",
+            "calibration_due_at": "2020-02-01T00:00:00Z",
+            "calibration_record": "tests/evidence/calibration-example.json",
+            "plausibility_test": "tests/evidence/plausibility-example.json",
+            "availability_test": "tests/evidence/availability-example.json",
+        })
+        blockers = validator.manifest_readiness(source)
+        self.assertIn("SNS-001: calibration is stale", blockers)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Expands the bounded Fast Solids Lab Experiment 001 manifest without inventing apparatus values or changing its modeled evidence status.

The patch adds the missing mechanical, air/pressure, thermal, electrical, material, stop/recovery, and access/service evidence fields; requires complete sensor calibration, plausibility, and availability records; records independent physical fallbacks for required interlocks; and makes RUN authorization a separate evidence-bearing admission act.

The fail-closed validator now enforces the complete Experiment 001 datum-ID inventory, rejects omitted requirements, rejects stale calibration, requires tolerances for verified physical values, and refuses RUN without complete authorization. Generated safety documentation now reports readiness counts.

## Verification

- `python3 -m json.tool` passes for the manifest and schema.
- `python3 scripts/render-safety.py --check` passes.
- `python3 -m unittest tests/test_validate_safety.py` passes: 8 tests.
- `python3 scripts/validate-safety.py` passes structural validation while reporting the manifest BLOCKED.
- `python3 scripts/validate-safety.py --require-runnable` fails intentionally because no apparatus evidence has been supplied.

Closes no safety blocker by assertion; Experiment 001 remains `M` and `approved_for_run: false`.